### PR TITLE
Support loading templates from stdin.

### DIFF
--- a/gucci_test.go
+++ b/gucci_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"testing"
-	"text/template"
 )
 
 var testMap = map[string]string{
@@ -38,6 +37,13 @@ func TestFuncShellError(t *testing.T) {
 	tpl := `{{ shell "non-existent" }}`
 	if err := runTest(tpl, ""); err == nil {
 		t.Error("expected error missing")
+	}
+}
+
+func TestFuncShellPipe(t *testing.T) {
+	tpl := `{{ shell "echo foo | grep foo" }}`
+	if err := runTest(tpl, "foo"); err != nil {
+		t.Error(err)
 	}
 }
 
@@ -85,14 +91,14 @@ func TestNoArgs(t *testing.T) {
 	os.Args = oldArgs
 }
 
-func runTest(tpl, expect string) error {
-
-	t, err := template.New("test").Funcs(funcMap).Parse(tpl)
+func runTest(str, expect string) error {
+	tpl, err := LoadString("test", str)
 	if err != nil {
 		return err
 	}
+
 	var b bytes.Buffer
-	err = t.Execute(&b, testMap)
+	err = ExecuteTemplate(testMap, &b, tpl)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
A template can now be loaded from stdin or via a file name argument. Gucci now looks to stdin for a template when the file argument is omitted, which means that arguments are now optional. Have to use `-h` to see help now, rather than just `gucci`.

Feel free to use this as the basis for your own refactoring to support this feature, if that's the direction you want to take, if I've not implemented it in line with your vision.
