### PR TITLE
Fix panic from tpl.Option

### DIFF
--- a/gucci.go
+++ b/gucci.go
@@ -120,6 +120,7 @@ func loadVariables(c *cli.Context) (map[string]interface{}, error) {
 }
 
 func executeTemplate(valuesIn map[string]interface{}, out io.Writer, tpl *template.Template) error {
+	tpl.Option("missingkey=error")
 	err := tpl.Execute(out, valuesIn)
 	if err != nil {
 		return fmt.Errorf("Failed to parse standard input: %v", err)
@@ -129,8 +130,6 @@ func executeTemplate(valuesIn map[string]interface{}, out io.Writer, tpl *templa
 
 func run(tplPath string, vars map[string]interface{}) error {
 	tpl, err := loadTemplateFileOrStdin(tplPath)
-	tpl = tpl.Option("missingkey=error")
-
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I was running into a panic when attempting to template with a function that doesn't exist. I moved the `tpl.Option("missingkey=error")` so that it occurs after the error handling for `loadTemplateFileOrStdin`. 

Here is the panic information I got. 

```
➜  gucci git:(add-toYaml-support) ./gucci -f vars.yml template.tpl
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x1111147]

goroutine 1 [running]:
text/template.(*Template).init(...)
	/usr/local/Cellar/go/1.12.1/libexec/src/text/template/template.go:66
text/template.(*Template).Option(0x0, 0xc0000f3af8, 0x1, 0x1, 0xc00009f160)
	/usr/local/Cellar/go/1.12.1/libexec/src/text/template/option.go:43 +0x27
main.run(0x7ffeefbffafc, 0xc, 0xc0000a4f30, 0x0, 0x0)
	/Users/noqcks/data/noqcks/gucci/gucci.go:133 +0x94
main.main.func1(0xc000136000, 0x0, 0x0)
	/Users/noqcks/data/noqcks/gucci/gucci.go:53 +0x109
github.com/urfave/cli.HandleAction(0x12abdc0, 0x130ec58, 0xc000136000, 0x0, 0x0)
	/Users/noqcks/go/src/github.com/urfave/cli/app.go:502 +0xbe
github.com/urfave/cli.(*App).Run(0xc00012e000, 0xc00009c000, 0x4, 0x4, 0x0, 0x0)
	/Users/noqcks/go/src/github.com/urfave/cli/app.go:268 +0x5aa
main.main()
	/Users/noqcks/data/noqcks/gucci/gucci.go:59 +0x2a6
```

