### PR TITLE
Deprecate old golang versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ sudo: false
 language: go
 
 go:
-- '1.9'
-- '1.10'
 - '1.11'
 - '1.12'
 - tip
@@ -12,6 +10,7 @@ env:
   global:
   - VERSION=$(cat VERSION)
   - LDFLAGS="-X main.AppVersion=$VERSION"
+  - GO111MODULE=on
 
 before_script:
 - go get github.com/onsi/ginkgo/ginkgo

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: go
 
 go:
-- '1.11'
 - '1.12'
 - tip
 
@@ -10,9 +9,7 @@ env:
   global:
   - VERSION=$(cat VERSION)
   - LDFLAGS="-X main.AppVersion=$VERSION"
-  # this cannot be enabled until we no longer support 1.11, urfave/cli
-  # supports onll > 1.12
-  # - GO111MODULE=on
+  - GO111MODULE=on
 
 before_script:
 - go get github.com/onsi/ginkgo/ginkgo

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ env:
   global:
   - VERSION=$(cat VERSION)
   - LDFLAGS="-X main.AppVersion=$VERSION"
-  - GO111MODULE=on
+  # this cannot be enabled until we no longer support 1.11, urfave/cli
+  # supports onll > 1.12
+  # - GO111MODULE=on
 
 before_script:
 - go get github.com/onsi/ginkgo/ginkgo


### PR DESCRIPTION
Golang is having issues testing and building on travisci with go versions <1.12. It should be fine to deprecate all older versions, especially ones not supported any longer.