### PR TITLE
Allow setting tpl opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ foo:
 
 Existing [golang templating options](https://golang.org/pkg/text/template/#Template.Option) can be used for templating.
 
-If no option is specified, the `missingkey=error` option will be used (execution stops inmediately with an error if a
+If no option is specified, the `missingkey=error` option will be used (execution stops immediately with an error if a
 key used in the template is not present in the supplied values).
 
 One might want a different value for `missingkey` when using conditionals and having keys that won't be

--- a/gucci.go
+++ b/gucci.go
@@ -47,6 +47,7 @@ func main() {
 		cli.StringSliceFlag{
 			Name: flagSetOptLong,
 			Usage: "A template option (`KEY=VALUE`) to be applied",
+			Value: &cli.StringSlice{"missingkey=error"},
 		},
 	}
 
@@ -56,25 +57,13 @@ func main() {
 		if err != nil {
 			return cli.NewExitError(err, 1)
 		}
-
-		tplOpt := getTplOpt(c.StringSlice(flagSetOpt))
-
-		err = run(tplPath, vars, tplOpt)
+		err = run(tplPath, vars, c.StringSlice(flagSetOpt))
 		if err != nil {
 			return cli.NewExitError(err, 1)
 		}
 		return nil
 	}
 	app.Run(os.Args)
-}
-
-func getTplOpt(cliTplOpt []string) []string {
-	// Default behaviour if no options specified is to fail on missing keys
-	if len(cliTplOpt) == 0 {
-		cliTplOpt = append(cliTplOpt, "missingkey=error")
-	}
-
-	return cliTplOpt
 }
 
 func loadInputVarsFile(c *cli.Context) (map[string]interface{}, error) {

--- a/gucci_test.go
+++ b/gucci_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"reflect"
 	"testing"
 )
 
@@ -52,7 +53,7 @@ func runTest(str, expect string) error {
 	}
 
 	var b bytes.Buffer
-	err = executeTemplate(testVarMap, &b, tpl)
+	err = executeTemplate(testVarMap, &b, tpl, []string{})
 	if err != nil {
 		return err
 	}
@@ -60,4 +61,37 @@ func runTest(str, expect string) error {
 		return fmt.Errorf("Expected '%s', got '%s'", expect, b.String())
 	}
 	return nil
+}
+
+func Test_getTplOpt(t *testing.T) {
+	type args struct {
+		cliTplOpt []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "Default value if no option specified",
+			args: args {
+				cliTplOpt: []string{},
+			},
+			want: []string{"missingkey=error"},
+		},
+		{
+			name: "Specified Option",
+			args: args {
+				cliTplOpt: []string{"missingkey=zero"},
+			},
+			want: []string{"missingkey=zero"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getTplOpt(tt.args.cliTplOpt); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getTplOpt() = %v, want %v", got, tt.want)
+			}
+	})
+}
 }

--- a/gucci_test.go
+++ b/gucci_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"reflect"
 	"testing"
 )
 
@@ -61,37 +60,4 @@ func runTest(str, expect string) error {
 		return fmt.Errorf("Expected '%s', got '%s'", expect, b.String())
 	}
 	return nil
-}
-
-func Test_getTplOpt(t *testing.T) {
-	type args struct {
-		cliTplOpt []string
-	}
-	tests := []struct {
-		name string
-		args args
-		want []string
-	}{
-		{
-			name: "Default value if no option specified",
-			args: args {
-				cliTplOpt: []string{},
-			},
-			want: []string{"missingkey=error"},
-		},
-		{
-			name: "Specified Option",
-			args: args {
-				cliTplOpt: []string{"missingkey=zero"},
-			},
-			want: []string{"missingkey=zero"},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := getTplOpt(tt.args.cliTplOpt); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getTplOpt() = %v, want %v", got, tt.want)
-			}
-	})
-}
 }


### PR DESCRIPTION
This PR closes #27 by allowing setting [template options ](https://golang.org/pkg/text/template/#Template.Option) when rendering a template. If no option is provided, the `missingkey=error` option is used for backwards compatibility.

~~I have also updated dependencies in a separate commit (tests still look fine after upgrading versions).~~ -> I have now removed the dependency update commit since there is a broken dependency (I think it comes from using Go < 1.13)

Feel free to make any comment or change request for anything not aligned with the rest of the repository.