### PR TITLE
shell function, multiple arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ go:
 env:
   global:
   - VERSION=$(cat VERSION)
-  - LDFLAGS='-X main.AppVersion='$VERSION' -w -extldflags "static"'
+  - LDFLAGS="-X main.AppVersion=$VERSION -w -extldflags static"
   - GO111MODULE=on
 before_script:
 - go get github.com/onsi/ginkgo/ginkgo

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ go:
 env:
   global:
   - VERSION=$(cat VERSION)
-  - LDFLAGS='-X main.AppVersion=$VERSION -w -extldflags "static"'
+  - LDFLAGS='-X main.AppVersion='$VERSION' -w -extldflags "static"'
   - GO111MODULE=on
 before_script:
 - go get github.com/onsi/ginkgo/ginkgo

--- a/README.md
+++ b/README.md
@@ -176,8 +176,13 @@ Furthermore, this tool also includes custom functions:
    ```
    {{ shell "echo hello world" }}
    ```
+   and
+   ```
+   # guest: world
+   {{ shell "echo hello " .guest }}
+   ```
 
-   Produces:
+   Both produce:
 
    ```
    hello world

--- a/funcs.go
+++ b/funcs.go
@@ -23,8 +23,8 @@ func getFuncMap() template.FuncMap {
 	return f
 }
 
-func shell(cmd string) (string, error) {
-	out, err := exec.Command("bash", "-c", cmd).Output()
+func shell(cmd ...string) (string, error) {
+	out, err := exec.Command("bash", "-c", strings.Join(cmd[:], "")).Output()
 	if err != nil {
 		return "", errors.Wrap(err, "Issue running command")
 	}

--- a/gucci_test.go
+++ b/gucci_test.go
@@ -24,6 +24,13 @@ func TestFuncShell(t *testing.T) {
 	}
 }
 
+func TestFuncShellArguments(t *testing.T) {
+	tpl := `{{ shell "echo " "hello" "world"}}`
+	if err := runTest(tpl, "helloworld"); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestFuncShellError(t *testing.T) {
 	tpl := `{{ shell "non-existent" }}`
 	if err := runTest(tpl, ""); err == nil {


### PR DESCRIPTION
Allow `shell` function to have dynamic arguments, so that in template it can be used in such a way:
`{{ shell "echo " "hello " .user.name ", we missed you!" }}`.

Also, fixed Travis to have proper `--version` info (at the moment, printing `gucci version $VERSION`).