### PR TITLE
implement 'include' template function

### DIFF
--- a/funcs.go
+++ b/funcs.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"fmt"
 	"os/exec"
 	"strings"
 	"text/template"
@@ -10,17 +12,34 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-var funcMap = getFuncMap()
-
-func getFuncMap() template.FuncMap {
+func getFuncMap(t *template.Template) template.FuncMap {
 	f := sprig.TxtFuncMap()
 	delete(f, "env")
 	delete(f, "expandenv")
 
+	f["include"] = include(t)
 	f["shell"] = shell
 	f["toYaml"] = toYaml
 
 	return f
+}
+
+func include(t *template.Template) func(templateName string, vars ...interface{}) (string, error) {
+	return func(templateName string, vars ...interface{}) (string, error) {
+		if len(vars) > 1 {
+			return "", errors.New(fmt.Sprintf("Call to include may pass zero or one vars structure, got %v.", len(vars)))
+		}
+		buf := bytes.NewBuffer(nil)
+		included := t.Lookup(templateName)
+		if included == nil {
+			return "", errors.New(fmt.Sprintf("No such template '%v' found while calling 'include'.", templateName))
+		}
+		
+	  if err := included.ExecuteTemplate(buf, templateName, vars[0]); err != nil {
+	      return "", err
+	  }
+	  return buf.String(), nil
+	}
 }
 
 func shell(cmd ...string) (string, error) {

--- a/gucci_test.go
+++ b/gucci_test.go
@@ -17,6 +17,41 @@ func TestSub(t *testing.T) {
 	}
 }
 
+func TestFuncIncludeNoVars(t *testing.T) {
+	tpl := `{{ define "a" }}Hi Jane{{ end }}{{ include "a" . }}`
+	if err := runTest(tpl, "Hi Jane"); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestFuncIncludeWithVars(t *testing.T) {
+	tpl := `{{ define "a" }}Hi {{ .name }}{{ end }}{{ $_ := set . "name" "John" }}{{ include "a" . }}`
+	if err := runTest(tpl, "Hi John"); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestFuncIncludePipe(t *testing.T) {
+	tpl := `{{ define "a" }}Hi Jane{{ end }}{{ include "a" . | indent 2 }}`
+	if err := runTest(tpl, "  Hi Jane"); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestFuncIncludeTooManyVars(t *testing.T) {
+	tpl := `{{ define "a" }}Hi {{ .name }}{{ end }}{{ $_ := set . "name" "John" }}{{ include "a" . . }}`
+	if err := runTest(tpl, ""); err == nil {
+		t.Error("expected error to many vars")
+	}
+}
+
+func TestFuncIncludeBadName(t *testing.T) {
+	tpl := `{{ define "a" }}Hi Jane{{ end }}{{ include "b" . }}`
+	if err := runTest(tpl, ""); err == nil {
+		t.Error("expected error bad template name")
+	}
+}
+
 func TestFuncShell(t *testing.T) {
 	tpl := `{{ shell "echo hello" }}`
 	if err := runTest(tpl, "hello"); err != nil {

--- a/util.go
+++ b/util.go
@@ -30,7 +30,8 @@ func getKeyVal(item string) (key, val string) {
 
 func loadTemplateFile(tplFile string) (*template.Template, error) {
 	tplName := filepath.Base(tplFile)
-	tpl, err := template.New(tplName).Funcs(funcMap).ParseFiles(tplFile)
+	tpl := template.New(tplName)
+	_, err := tpl.Funcs(getFuncMap(tpl)).ParseFiles(tplFile)
 	if err != nil {
 		return nil, fmt.Errorf("Error parsing template(s): %v", err)
 	}
@@ -47,7 +48,8 @@ func loadTemplateStream(name string, in io.Reader) (*template.Template, error) {
 }
 
 func loadTemplateString(name, s string) (*template.Template, error) {
-	tpl, err := template.New(name).Funcs(funcMap).Parse(s)
+	tpl := template.New(name)
+	tpl, err := tpl.Funcs(getFuncMap(tpl)).Parse(s)
 	if err != nil {
 		return nil, fmt.Errorf("Error parsing template(s): %v", err)
 	}


### PR DESCRIPTION
Closes #37 

Implements 'include' template function, allowing piping and further manipulation of 'define'd templates.