### PR TITLE
Shell: stdout in error details

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: release
+
+on:
+  push:
+    branches:
+      - '*'
+jobs:
+  test:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+      - name: Install Ginkgo
+        run: go get github.com/onsi/ginkgo/ginkgo
+      - name: Test
+        run: ginkgo ./...

--- a/funcs.go
+++ b/funcs.go
@@ -34,20 +34,21 @@ func include(t *template.Template) func(templateName string, vars ...interface{}
 		if included == nil {
 			return "", errors.New(fmt.Sprintf("No such template '%v' found while calling 'include'.", templateName))
 		}
-		
-	  if err := included.ExecuteTemplate(buf, templateName, vars[0]); err != nil {
-	      return "", err
-	  }
-	  return buf.String(), nil
+
+		if err := included.ExecuteTemplate(buf, templateName, vars[0]); err != nil {
+			return "", err
+		}
+		return buf.String(), nil
 	}
 }
 
 func shell(cmd ...string) (string, error) {
 	out, err := exec.Command("bash", "-c", strings.Join(cmd[:], "")).Output()
-	if err != nil {
-		return "", errors.Wrap(err, "Issue running command")
-	}
 	output := strings.TrimSpace(string(out))
+	if err != nil {
+		return "", errors.Wrap(err, "Issue running command: "+output)
+	}
+
 	return output, nil
 }
 

--- a/gucci_test.go
+++ b/gucci_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -70,6 +71,14 @@ func TestFuncShellError(t *testing.T) {
 	tpl := `{{ shell "non-existent" }}`
 	if err := runTest(tpl, ""); err == nil {
 		t.Error("expected error missing")
+	}
+}
+
+func TestFuncShellDetailedError(t *testing.T) {
+	tpl := `{{ shell "echo saboteur ; exit 1" }}`
+	err := runTest(tpl, "")
+	if !strings.Contains(err.Error(), "saboteur") {
+		t.Error("expected stdout in error missing. actual: ", err)
 	}
 }
 


### PR DESCRIPTION
Added stdout as part of wrapped error details, so that caller can inspect what happened while executing given command. Stdout seems to be enough, for example error message from bash commands or scripts.

Additionally, added a `ci` Action, to only check tests executions on branches (as an alternative to your current Travis integration, since you're already using Actions to perform releases). That's useful in forked repos, hope it is here as well!