### PR TITLE
Restore env and expandenv.

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ All of the existing [golang templating functions](https://golang.org/pkg/text/te
 
 ### Sprig Functions
 
-gucci ships with the [sprig templating functions library](http://masterminds.github.io/sprig/) offering a wide variety of template helpers. Sprig's `env` and `expandenv` functions are disabled in favor of gucci's own environment variable parsing (see below).
+gucci ships with the [sprig templating functions library](http://masterminds.github.io/sprig/) offering a wide variety of template helpers.
 
 ### Built In Functions
 

--- a/funcs.go
+++ b/funcs.go
@@ -14,8 +14,6 @@ import (
 
 func getFuncMap(t *template.Template) template.FuncMap {
 	f := sprig.TxtFuncMap()
-	delete(f, "env")
-	delete(f, "expandenv")
 
 	f["include"] = include(t)
 	f["shell"] = shell


### PR DESCRIPTION
Although the ability to reference environment variables with the `{{ .VARNAME }}` syntax is useful, it throws when `VARNAME` is not defined.

It is sometimes useful to have the shell behaviour of an undefined environment variable expanding to the empty string.

For instance, when `FOO` is undefined, template `It is set to "{{ .FOO }}"` throws `map has no entry for key "FOO"` when it might be desirable for it to expand to `It is set to ""` instead.

With `env`, the above is possible.  `It is set to "{{ env "FOO" }}"` works as expected.

#14 added Sprig functions, which is nice, and removed `env` and `expandenv` with the justification that "Helm doesn't have them" but I think they are useful enough to keep.